### PR TITLE
Standardize health check response structure

### DIFF
--- a/app/api/health_routes.py
+++ b/app/api/health_routes.py
@@ -1,46 +1,46 @@
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Response, status
 from psycopg import Error as PsycopgError
 
 from app.db.connection import check_database_connection
 from app.schemas.health_schema import HealthResponse
-from app.services.health_service import get_health_status
+from app.services.health_service import get_database_health_status, get_health_status
 
 
 router = APIRouter(tags=["Health"])
 
 
-@router.get("/health", response_model=HealthResponse)
-def health_check():
+@router.get(
+    "/health",
+    response_model=HealthResponse,
+    response_model_exclude_none=True,
+)
+def health_check() -> HealthResponse:
     return get_health_status()
 
 
-@router.get("/health/db")
-def database_health_check():
+@router.get(
+    "/health/db",
+    response_model=HealthResponse,
+    response_model_exclude_none=True,
+)
+def database_health_check(response: Response) -> HealthResponse:
     try:
         is_connected = check_database_connection()
     except PsycopgError as error:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail={
-                "status": "ERROR",
-                "service": "database",
-                "message": "Database is not reachable",
-                "error": error.__class__.__name__,
-            },
-        ) from error
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
 
-    if not is_connected:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail={
-                "status": "ERROR",
-                "service": "database",
-                "message": "Database health check failed",
-            },
+        return get_database_health_status(
+            is_connected=False,
+            message="Database is not reachable",
+            error=error.__class__.__name__,
         )
 
-    return {
-        "status": "OK",
-        "service": "database",
-        "message": "Database is reachable",
-    }
+    if not is_connected:
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+
+        return get_database_health_status(
+            is_connected=False,
+            message="Database health check failed",
+        )
+
+    return get_database_health_status(is_connected=True)

--- a/app/schemas/health_schema.py
+++ b/app/schemas/health_schema.py
@@ -1,8 +1,24 @@
+from typing import Literal
+
 from pydantic import BaseModel
 
 
-class HealthResponse(BaseModel):
-    status: str
-    service: str
+HealthStatus = Literal["OK", "ERROR"]
+
+
+class ServiceMetadata(BaseModel):
+    name: str
     environment: str
     version: str
+
+
+class HealthCheck(BaseModel):
+    status: HealthStatus
+    message: str
+    error: str | None = None
+
+
+class HealthResponse(BaseModel):
+    status: HealthStatus
+    service: ServiceMetadata
+    checks: dict[str, HealthCheck]

--- a/app/services/health_service.py
+++ b/app/services/health_service.py
@@ -1,11 +1,54 @@
 from app.config import settings
-from app.schemas.health_schema import HealthResponse
+from app.schemas.health_schema import HealthCheck, HealthResponse, ServiceMetadata
+
+
+def get_service_metadata() -> ServiceMetadata:
+    return ServiceMetadata(
+        name=settings.app_name,
+        environment=settings.app_env,
+        version=settings.app_version,
+    )
 
 
 def get_health_status() -> HealthResponse:
     return HealthResponse(
         status="OK",
-        service=settings.app_name,
-        environment=settings.app_env,
-        version=settings.app_version,
+        service=get_service_metadata(),
+        checks={
+            "application": HealthCheck(
+                status="OK",
+                message="Application is running",
+            )
+        },
+    )
+
+
+def get_database_health_status(
+    *,
+    is_connected: bool,
+    message: str | None = None,
+    error: str | None = None,
+) -> HealthResponse:
+    if is_connected:
+        return HealthResponse(
+            status="OK",
+            service=get_service_metadata(),
+            checks={
+                "database": HealthCheck(
+                    status="OK",
+                    message=message or "Database is reachable",
+                )
+            },
+        )
+
+    return HealthResponse(
+        status="ERROR",
+        service=get_service_metadata(),
+        checks={
+            "database": HealthCheck(
+                status="ERROR",
+                message=message or "Database is not reachable",
+                error=error,
+            )
+        },
     )

--- a/tests/integration/test_app_health_integration.py
+++ b/tests/integration/test_app_health_integration.py
@@ -3,30 +3,40 @@ import requests
 
 
 BASE_URL = "http://localhost:18000"
+EXPECTED_SERVICE = {
+    "name": "Spend Analyzer",
+    "environment": "test",
+    "version": "0.1.0",
+}
 
 
 @pytest.mark.integration
 def test_app_health_endpoint_works_through_running_container():
-    response = requests.get(f"{BASE_URL}/health", timeout=5)
+    response = requests.get(BASE_URL + "/health", timeout=5)
 
     assert response.status_code == 200
 
     body = response.json()
 
     assert body["status"] == "OK"
-    assert body["service"] == "Spend Analyzer"
-    assert body["environment"] == "test"
-    assert body["version"] == "0.1.0"
+    assert body["service"] == EXPECTED_SERVICE
+    assert body["checks"]["application"] == {
+        "status": "OK",
+        "message": "Application is running",
+    }
 
 
 @pytest.mark.integration
 def test_database_health_endpoint_connects_from_app_container_to_db_container():
-    response = requests.get(f"{BASE_URL}/health/db", timeout=5)
+    response = requests.get(BASE_URL + "/health/db", timeout=5)
 
     assert response.status_code == 200
 
     body = response.json()
 
     assert body["status"] == "OK"
-    assert body["service"] == "database"
-    assert body["message"] == "Database is reachable"
+    assert body["service"] == EXPECTED_SERVICE
+    assert body["checks"]["database"] == {
+        "status": "OK",
+        "message": "Database is reachable",
+    }

--- a/tests/unit/test_health_routes.py
+++ b/tests/unit/test_health_routes.py
@@ -7,6 +7,12 @@ from app.main import app
 client = TestClient(app)
 
 
+def assert_service_metadata(body):
+    assert body["service"]["name"] == "Spend Analyzer"
+    assert body["service"]["environment"] == "test"
+    assert body["service"]["version"] == "0.1.0"
+
+
 def test_health_check_returns_application_status():
     response = client.get("/health")
 
@@ -15,9 +21,9 @@ def test_health_check_returns_application_status():
     body = response.json()
 
     assert body["status"] == "OK"
-    assert body["service"] == "Spend Analyzer"
-    assert body["environment"] == "test"
-    assert body["version"] == "0.1.0"
+    assert_service_metadata(body)
+    assert body["checks"]["application"]["status"] == "OK"
+    assert body["checks"]["application"]["message"] == "Application is running"
 
 
 def test_database_health_check_returns_ok_when_database_is_reachable(monkeypatch):
@@ -36,8 +42,9 @@ def test_database_health_check_returns_ok_when_database_is_reachable(monkeypatch
     body = response.json()
 
     assert body["status"] == "OK"
-    assert body["service"] == "database"
-    assert body["message"] == "Database is reachable"
+    assert_service_metadata(body)
+    assert body["checks"]["database"]["status"] == "OK"
+    assert body["checks"]["database"]["message"] == "Database is reachable"
 
 
 def test_database_health_check_returns_503_when_database_is_unreachable(monkeypatch):
@@ -55,7 +62,29 @@ def test_database_health_check_returns_503_when_database_is_unreachable(monkeypa
 
     body = response.json()
 
-    assert body["detail"]["status"] == "ERROR"
-    assert body["detail"]["service"] == "database"
-    assert body["detail"]["message"] == "Database is not reachable"
-    assert body["detail"]["error"] == "OperationalError"
+    assert body["status"] == "ERROR"
+    assert_service_metadata(body)
+    assert body["checks"]["database"]["status"] == "ERROR"
+    assert body["checks"]["database"]["message"] == "Database is not reachable"
+    assert body["checks"]["database"]["error"] == "OperationalError"
+
+
+def test_database_health_check_returns_503_when_database_health_check_fails(monkeypatch):
+    def fake_check_database_connection():
+        return False
+
+    monkeypatch.setattr(
+        "app.api.health_routes.check_database_connection",
+        fake_check_database_connection,
+    )
+
+    response = client.get("/health/db")
+
+    assert response.status_code == 503
+
+    body = response.json()
+
+    assert body["status"] == "ERROR"
+    assert_service_metadata(body)
+    assert body["checks"]["database"]["status"] == "ERROR"
+    assert body["checks"]["database"]["message"] == "Database health check failed"


### PR DESCRIPTION
## Summary

Standardizes `/health` and `/health/db` responses to use the same structured response contract.

## Changes

- Added structured `HealthResponse` model
- Added `ServiceMetadata` model
- Added reusable `HealthCheck` model
- Updated `/health` to return an `application` check
- Updated `/health/db` to return a `database` check
- Updated database failure responses to return the same top-level response model with HTTP 503
- Updated unit tests for success, DB exception, and DB false-result cases
- Updated integration tests for the new response shape

## Response shape

```json
{
  "status": "OK",
  "service": {
    "name": "Spend Analyzer",
    "environment": "test",
    "version": "0.1.0"
  },
  "checks": {
    "database": {
      "status": "OK",
      "message": "Database is reachable"
    }
  }
}
```

## Testing

GitHub Build will run `python -m pytest --all`.
