### PR TITLE
MVP 1 - Issue 6: Implement JWT validation and authenticated user context

### DIFF
--- a/app/api/me_routes.py
+++ b/app/api/me_routes.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Depends
+
+from app.auth.dependencies import get_current_user
+from app.schemas.auth_schema import AuthenticatedUser, MeResponse
+
+
+router = APIRouter(tags=["Users"])
+
+
+@router.get("/me", response_model=MeResponse)
+def get_me(current_user: AuthenticatedUser = Depends(get_current_user)) -> MeResponse:
+    return MeResponse(
+        user_id=current_user.user_id,
+        username=current_user.username,
+        email=current_user.email,
+    )

--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -1,0 +1,25 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+
+from app.auth.jwt_validator import JwtValidationError, validate_access_token
+from app.schemas.auth_schema import AuthenticatedUser
+
+
+outh2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+
+def get_current_user(token: str = Depends(outh2_scheme)) -> AuthenticatedUser:
+    try:
+        claims = validate_access_token(token)
+    except JwtValidationError as error:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid authentication credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from error
+
+    return AuthenticatedUser(
+        user_id=claims["sub"],
+        username=claims.get("preferred_username"),
+        email=claims.get("email"),
+    )

--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -5,10 +5,10 @@ from app.auth.jwt_validator import JwtValidationError, validate_access_token
 from app.schemas.auth_schema import AuthenticatedUser
 
 
-outh2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
 
-def get_current_user(token: str = Depends(outh2_scheme)) -> AuthenticatedUser:
+def get_current_user(token: str = Depends(oauth2_scheme)) -> AuthenticatedUser:
     try:
         claims = validate_access_token(token)
     except JwtValidationError as error:

--- a/app/auth/jwt_validator.py
+++ b/app/auth/jwt_validator.py
@@ -1,0 +1,74 @@
+from functools import lru_cache
+from typing import Any
+
+from jose import ExpiredSignatureError, JWTError, jwt
+import requests
+
+from app.config import settings
+
+
+class JwtValidationError(Exception):
+    """
+    Raised when JWT validation fails.
+    """
+
+
+@lru_cache(maxsize=1)
+def get_jwks() -> dict[str, Any]:
+    """
+    Fetch and cache JSON Web Key Set from the configured OIDC provider.
+
+    This is acceptable for MVP/local development. In production, this should
+    eventually become a TTL cache because identity providers can rotate keys.
+    """
+    response = requests.get(settings.oidc_jwks_url, timeout=5)
+    response.raise_for_status()
+
+    return response.json()
+
+
+def get_signing_key(token: str) -> dict[str, Any]:
+    try:
+        header = jwt.get_unverified_header(token)
+    except JWTError as error:
+        raise JwtValidationError("Malformed token header") from error
+
+    key_id = header.get("kid")
+
+    if not key_id:
+        raise JwtValidationError("Token header does not contain kid")
+
+    jwks = get_jwks()
+
+    for key in jwks.get("keys", []):
+        if key.get("kid") == key_id:
+            return key
+
+    raise JwtValidationError("Matching signing key was not found")
+
+
+def validate_access_token(token: str) -> dict[str, Any]:
+    """
+    Validate access token signature, issuer, audience, and expiry.
+    """
+    signing_key = get_signing_key(token)
+
+    try:
+        claims = jwt.decode(
+            token=token,
+            key=signing_key,
+            algorithms=["RS256"],
+            audience=settings.oidc_audience,
+            issuer=settings.oidc_issuer_url,
+        )
+    except ExpiredSignatureError as error:
+        raise JwtValidationError("Token has expired") from error
+    except JWTError as error:
+        raise JwtValidationError("Token validation failed") from error
+
+    subject = claims.get("sub")
+
+    if not subject:
+        raise JwtValidationError("Token does not conation subject")
+
+    return claims

--- a/app/auth/jwt_validator.py
+++ b/app/auth/jwt_validator.py
@@ -1,8 +1,8 @@
 from functools import lru_cache
 from typing import Any
 
-from jose import ExpiredSignatureError, JWTError, jwt
 import requests
+from jose import ExpiredSignatureError, JWTError, jwt
 
 from app.config import settings
 
@@ -69,6 +69,6 @@ def validate_access_token(token: str) -> dict[str, Any]:
     subject = claims.get("sub")
 
     if not subject:
-        raise JwtValidationError("Token does not conation subject")
+        raise JwtValidationError("Token does not contain subject")
 
     return claims

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 
 from app.api.health_routes import router as health_router
+from app.api.me_routes import router as me_router
 from app.config import settings
 
 
@@ -12,7 +13,9 @@ def create_app() -> FastAPI:
     )
 
     app.include_router(health_router)
-    
+    app.include_router(me_router)
+
     return app
+
 
 app = create_app()

--- a/app/schemas/auth_schema.py
+++ b/app/schemas/auth_schema.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+
+class AuthenticatedUser(BaseModel):
+    user_id: str
+    username: str | None = None
+    email: str | None = None
+
+
+class MeResponse(BaseModel):
+    user_id: str
+    username: str | None = None
+    email: str | None = None

--- a/tests/integration/test_me_integration.py
+++ b/tests/integration/test_me_integration.py
@@ -1,0 +1,69 @@
+import pytest
+import requests
+
+from tests.support.readiness import wait_for_http_ok
+
+
+APP_BASE_URL = "http://localhost:18000"
+KEYCLOAK_BASE_URL = "http://localhost:58080"
+REALM = "spend-analyzer"
+TOKEN_ENDPOINT = f"{KEYCLOAK_BASE_URL}/realms/{REALM}/protocol/openid-connect/token"
+DISCOVERY_ENDPOINT = (
+    f"{KEYCLOAK_BASE_URL}/realms/{REALM}/.well-known/openid-configuration"
+)
+
+
+def get_local_access_token() -> str:
+    wait_for_http_ok(DISCOVERY_ENDPOINT)
+
+    response = requests.post(
+        TOKEN_ENDPOINT,
+        data={
+            "grant_type": "password",
+            "client_id": "spend-analyzer-local",
+            "username": "test.user",
+            "password": "change_me",
+        },
+        timeout=10,
+    )
+
+    assert response.status_code == 200
+
+    return response.json()["access_token"]
+
+
+@pytest.mark.integration
+def test_me_returns_401_without_token():
+    response = requests.get(f"{APP_BASE_URL}/me", timeout=5)
+
+    assert response.status_code == 401
+
+
+@pytest.mark.integration
+def test_me_returns_authenticated_user_for_valid_token():
+    token = get_local_access_token()
+
+    response = requests.get(
+        f"{APP_BASE_URL}/me",
+        headers={"Authorization": f"Bearer {token}"},
+        timeout=5,
+    )
+
+    assert response.status_code == 200
+
+    body = response.json()
+
+    assert body["user_id"]
+    assert body["username"] == "test.user"
+    assert body["email"] == "test.user@example.com"
+
+
+@pytest.mark.integration
+def test_me_returns_401_for_malformed_token():
+    response = requests.get(
+        f"{APP_BASE_URL}/me",
+        headers={"Authorization": "Bearer not-a-valid-token"},
+        timeout=5,
+    )
+
+    assert response.status_code == 401

--- a/tests/unit/test_auth_dependencies.py
+++ b/tests/unit/test_auth_dependencies.py
@@ -1,0 +1,45 @@
+import pytest
+from fastapi import HTTPException
+
+from app.auth.dependencies import get_current_user
+
+
+def test_get_current_user_returns_authenticated_user(monkeypatch):
+    def fake_validate_access_token(token: str):
+        assert token == "valid-token"
+
+        return {
+            "sub": "user-123",
+            "preferred_username": "test.user",
+            "email": "test.user@example.com",
+        }
+
+    monkeypatch.setattr(
+        "app.auth.dependencies.validate_access_token",
+        fake_validate_access_token,
+    )
+
+    current_user = get_current_user(token="valid-token")
+
+    assert current_user.user_id == "user-123"
+    assert current_user.username == "test.user"
+    assert current_user.email == "test.user@example.com"
+
+
+def test_get_current_user_raises_401_for_invalid_token(monkeypatch):
+    from app.auth.jwt_validator import JwtValidationError
+
+    def fake_validate_access_token(token: str):
+        raise JwtValidationError("invalid token")
+
+    monkeypatch.setattr(
+        "app.auth.dependencies.validate_access_token",
+        fake_validate_access_token,
+    )
+
+    with pytest.raises(HTTPException) as error:
+        get_current_user(token="invalid-token")
+
+    assert error.value.status_code == 401
+    assert error.value.detail == "Invalid authentication credentials"
+    assert error.value.headers == {"WWW-Authenticate": "Bearer"}


### PR DESCRIPTION
Closes #6.

## Summary

Implements JWT Bearer token validation and exposes authenticated user context through a protected `/me` endpoint.

## Changes

- Added JWT validation using configured OIDC JWKS
- Validates token signature, issuer, audience, and expiry
- Extracts authenticated user id from token `sub`
- Added `AuthenticatedUser` internal schema
- Added `MeResponse` API schema
- Added auth dependency for protected endpoints
- Added protected `GET /me` endpoint
- Registered `/me` router in FastAPI app
- Added unit tests for auth dependency
- Added integration tests for missing token, malformed token, and valid real Keycloak token

## Testing

```bash
pytest --unit
pytest --integration
pytest
```