### PR TITLE
Group Dependabot dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,20 @@
 version: 2
+
 updates:
   - package-ecosystem: pip
     directory: /
     schedule:
       interval: daily
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Groups Dependabot update PRs to reduce dependency-update noise.

## Changes

- Groups all Python dependency updates into one daily Dependabot PR.
- Groups all GitHub Actions updates into one weekly Dependabot PR.

## Why

Dependabot currently opens one PR per dependency update. Grouping keeps dependency maintenance easier to review while the existing CI gates still validate all updates together.

## Notes

Existing open Dependabot PRs may need to be closed or recreated before the next grouped PR appears.