### PR TITLE
Add Postman local smoke-test collection

### DIFF
--- a/docs/postman/README.md
+++ b/docs/postman/README.md
@@ -6,7 +6,7 @@ This directory contains a sanitized Postman collection, a local environment temp
 
 | Path | Purpose |
 |---|---|
-| `spend-analyser.postman_collection.json` | Postman collection for local health, auth, and ingestion smoke tests |
+| `spend-analyser.postman_collection.json` | Postman collection for local health, docs, auth, and ingestion smoke tests |
 | `spend-analyser-local.postman_environment.json` | Local Postman environment template with no committed token |
 | `files/sample-statement.pdf` | Valid dummy PDF statement for positive `/ingest` testing |
 | `files/invalid-sample-statement.pdf` | Invalid `.pdf` file for negative `/ingest` validation testing |
@@ -26,6 +26,8 @@ Confirm the local API and identity provider are reachable:
 ```text
 http://localhost:8000/health
 http://localhost:8000/health/db
+http://localhost:8000/docs
+http://localhost:8000/openapi.json
 http://localhost:8080/realms/spend-analyzer/.well-known/openid-configuration
 ```
 
@@ -52,14 +54,16 @@ Do not commit exported environments that contain a real `access_token`.
 
 ## Run order
 
-Run the requests in this order:
+Run the `Local` folder requests in this order:
 
 ```text
 1. Health
 2. DB Health
-3. Token
-4. Me
-5. Ingest
+3. Docs
+4. OpenAPI
+5. Token
+6. Me
+7. Ingest
 ```
 
 The `Token` request stores the returned token into the `access_token` environment variable. The `Me` and `Ingest` requests use that token automatically.
@@ -89,7 +93,7 @@ content_type = application/pdf
 
 ## Negative tests
 
-The collection also includes negative tests:
+The collection also includes a `Negative Tests` folder:
 
 | Request | Expected result |
 |---|---|

--- a/docs/postman/README.md
+++ b/docs/postman/README.md
@@ -1,0 +1,116 @@
+# Postman smoke-test collection
+
+This directory contains a sanitized Postman collection, a local environment template, and sample files for manually smoke-testing the local Spend Analyzer API.
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `spend-analyser.postman_collection.json` | Postman collection for local health, auth, and ingestion smoke tests |
+| `spend-analyser-local.postman_environment.json` | Local Postman environment template with no committed token |
+| `files/sample-statement.pdf` | Valid dummy PDF statement for positive `/ingest` testing |
+| `files/invalid-sample-statement.pdf` | Invalid `.pdf` file for negative `/ingest` validation testing |
+
+The sample PDFs contain dummy data only. They are for upload and validation smoke tests, not parser-accuracy tests.
+
+## Prerequisites
+
+Start the local stack from the repository root:
+
+```bash
+docker compose up -d --build
+```
+
+Confirm the local API and identity provider are reachable:
+
+```text
+http://localhost:8000/health
+http://localhost:8000/health/db
+http://localhost:8080/realms/spend-analyzer/.well-known/openid-configuration
+```
+
+## Import into Postman
+
+1. Open Postman.
+2. Import `spend-analyser.postman_collection.json`.
+3. Import `spend-analyser-local.postman_environment.json`.
+4. Select the `Spend Analyser Local` environment.
+
+The environment contains local defaults:
+
+```text
+api_base_url = http://localhost:8000
+idp_base_url = http://localhost:8080
+realm = spend-analyzer
+client_id = spend-analyzer-local
+username = test.user
+password = change_me
+access_token = <empty>
+```
+
+Do not commit exported environments that contain a real `access_token`.
+
+## Run order
+
+Run the requests in this order:
+
+```text
+1. Health
+2. DB Health
+3. Token
+4. Me
+5. Ingest
+```
+
+The `Token` request stores the returned token into the `access_token` environment variable. The `Me` and `Ingest` requests use that token automatically.
+
+## File upload setup
+
+The `Ingest` request uses the file form-data field:
+
+```text
+file = docs/postman/files/sample-statement.pdf
+```
+
+If Postman does not resolve the relative path after import, manually select:
+
+```text
+docs/postman/files/sample-statement.pdf
+```
+
+Expected successful `/ingest` result:
+
+```text
+201 Created
+status = UPLOADED
+original_file_name = sample-statement.pdf
+content_type = application/pdf
+```
+
+## Negative tests
+
+The collection also includes negative tests:
+
+| Request | Expected result |
+|---|---|
+| `Me - Missing Token` | `401 Unauthorized` |
+| `Ingest - Missing Token` | `401 Unauthorized` |
+| `Ingest - Invalid PDF Content` | `400 Bad Request` |
+
+For `Ingest - Invalid PDF Content`, attach:
+
+```text
+docs/postman/files/invalid-sample-statement.pdf
+```
+
+Expected response:
+
+```json
+{
+  "detail": "Uploaded file content is not a valid PDF"
+}
+```
+
+## Notes
+
+Postman pre-request scripts cannot attach an in-memory generated file to a multipart `file` field. The collection therefore uses checked-in local fixture files.

--- a/docs/postman/README.md
+++ b/docs/postman/README.md
@@ -54,7 +54,7 @@ Do not commit exported environments that contain a real `access_token`.
 
 ## Run order
 
-Run the `Local` folder requests in this order:
+Run these requests in order:
 
 ```text
 1. Health
@@ -76,11 +76,7 @@ The `Ingest` request uses the file form-data field:
 file = docs/postman/files/sample-statement.pdf
 ```
 
-If Postman does not resolve the relative path after import, manually select:
-
-```text
-docs/postman/files/sample-statement.pdf
-```
+If Postman does not resolve the relative path after import, manually select the same file manually from the repository checkout.
 
 Expected successful `/ingest` result:
 
@@ -93,28 +89,8 @@ content_type = application/pdf
 
 ## Negative tests
 
-The collection also includes a `Negative Tests` folder:
-
-| Request | Expected result |
-|---|---|
-| `Me - Missing Token` | `401 Unauthorized` |
-| `Ingest - Missing Token` | `401 Unauthorized` |
-| `Ingest - Invalid PDF Content` | `400 Bad Request` |
-
-For `Ingest - Invalid PDF Content`, attach:
-
-```text
-docs/postman/files/invalid-sample-statement.pdf
-```
-
-Expected response:
-
-```json
-{
-  "detail": "Uploaded file content is not a valid PDF"
-}
-```
+The collection also includes a `Negative Tests` folder for missing-token and invalid-file scenarios.
 
 ## Notes
 
-Postman pre-request scripts cannot attach an in-memory generated file to a multipart `file` field. The collection therefore uses checked-in local fixture files.
+Postman cannot attach generated in-memory content to a multipart file field. The collection therefore uses checked-in local fixture files.

--- a/docs/postman/files/invalid-sample-statement.pdf
+++ b/docs/postman/files/invalid-sample-statement.pdf
@@ -1,0 +1,3 @@
+This is not a valid PDF file.
+It intentionally does not start with the %PDF signature.
+Use this file to test invalid PDF upload validation.

--- a/docs/postman/files/sample-statement.pdf
+++ b/docs/postman/files/sample-statement.pdf
@@ -1,0 +1,66 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Courier >>
+endobj
+5 0 obj
+<< /Length 838 >>
+stream
+BT
+/F1 10 Tf
+50 750 Td
+(HDFC Bank Credit Card Statement) Tj
+0 -14 Td
+(Card Number: XXXX XXXX XXXX 4321) Tj
+0 -14 Td
+(Account Holder: James Bond) Tj
+0 -14 Td
+(Statement Period: 01 Apr 2024 - 30 Apr 2024) Tj
+0 -14 Td
+(Credit Limit: INR 2,00,000) Tj
+0 -14 Td
+(Available Credit: INR 1,45,230) Tj
+0 -14 Td
+() Tj
+0 -14 Td
+(Date        Description                          Amount \(INR\)) Tj
+0 -14 Td
+(03 Apr 2024 Swiggy Order #SWG123456              -450.00) Tj
+0 -14 Td
+(05 Apr 2024 Amazon.in Purchase                 -2,399.00) Tj
+0 -14 Td
+(15 Apr 2024 Payment Received                   +10,000.00) Tj
+0 -14 Td
+(Total Debits:  INR 2,849.00) Tj
+0 -14 Td
+(Total Credits: INR 10,000.00) Tj
+0 -14 Td
+(Minimum Amount Due: INR 2,738.50) Tj
+0 -14 Td
+(Payment Due Date: 20 May 2024) Tj
+0 -14 Td
+(Dummy statement for local smoke testing only.) Tj
+ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000309 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+1197
+%%EOF

--- a/docs/postman/spend-analyser-local.postman_environment.json
+++ b/docs/postman/spend-analyser-local.postman_environment.json
@@ -1,0 +1,51 @@
+{
+  "id": "48ebb8a8-2b91-4565-b517-ba74540cf856",
+  "name": "Spend Analyser Local",
+  "values": [
+    {
+      "key": "api_base_url",
+      "value": "http://localhost:8000",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "idp_base_url",
+      "value": "http://localhost:8080",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "realm",
+      "value": "spend-analyzer",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "client_id",
+      "value": "spend-analyzer-local",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "username",
+      "value": "test.user",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "password",
+      "value": "change_me",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "access_token",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    }
+  ],
+  "color": null,
+  "_postman_variable_scope": "environment",
+  "_postman_exported_using": "Postman/12.x"
+}

--- a/docs/postman/spend-analyser.postman_collection.json
+++ b/docs/postman/spend-analyser.postman_collection.json
@@ -7,7 +7,7 @@
   },
   "item": [
     {
-      "name": "Local Smoke Test",
+      "name": "Local",
       "item": [
         {
           "name": "Health",
@@ -32,8 +32,12 @@
             "header": [],
             "url": {
               "raw": "{{api_base_url}}/health",
-              "host": ["{{api_base_url}}"],
-              "path": ["health"]
+              "host": [
+                "{{api_base_url}}"
+              ],
+              "path": [
+                "health"
+              ]
             }
           },
           "response": []
@@ -61,8 +65,77 @@
             "header": [],
             "url": {
               "raw": "{{api_base_url}}/health/db",
-              "host": ["{{api_base_url}}"],
-              "path": ["health", "db"]
+              "host": [
+                "{{api_base_url}}"
+              ],
+              "path": [
+                "health",
+                "db"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Docs",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('Swagger UI HTML is returned', function () {",
+                  "  pm.expect(pm.response.text()).to.include('swagger-ui');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{api_base_url}}/docs",
+              "host": [
+                "{{api_base_url}}"
+              ],
+              "path": [
+                "docs"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "OpenAPI",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('OpenAPI document is returned', function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.openapi).to.be.a('string').and.not.empty;",
+                  "  pm.expect(json.info.title).to.be.a('string').and.not.empty;",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{api_base_url}}/openapi.json",
+              "host": [
+                "{{api_base_url}}"
+              ],
+              "path": [
+                "openapi.json"
+              ]
             }
           },
           "response": []
@@ -96,16 +169,40 @@
             "body": {
               "mode": "urlencoded",
               "urlencoded": [
-                {"key": "grant_type", "value": "password", "type": "text"},
-                {"key": "client_id", "value": "{{client_id}}", "type": "text"},
-                {"key": "username", "value": "{{username}}", "type": "text"},
-                {"key": "password", "value": "{{password}}", "type": "text"}
+                {
+                  "key": "grant_type",
+                  "value": "password",
+                  "type": "text"
+                },
+                {
+                  "key": "client_id",
+                  "value": "{{client_id}}",
+                  "type": "text"
+                },
+                {
+                  "key": "username",
+                  "value": "{{username}}",
+                  "type": "text"
+                },
+                {
+                  "key": "password",
+                  "value": "{{password}}",
+                  "type": "text"
+                }
               ]
             },
             "url": {
               "raw": "{{idp_base_url}}/realms/{{realm}}/protocol/openid-connect/token",
-              "host": ["{{idp_base_url}}"],
-              "path": ["realms", "{{realm}}", "protocol", "openid-connect", "token"]
+              "host": [
+                "{{idp_base_url}}"
+              ],
+              "path": [
+                "realms",
+                "{{realm}}",
+                "protocol",
+                "openid-connect",
+                "token"
+              ]
             }
           },
           "response": []
@@ -132,12 +229,20 @@
           "request": {
             "method": "GET",
             "header": [
-              {"key": "Authorization", "value": "Bearer {{access_token}}", "type": "text"}
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}",
+                "type": "text"
+              }
             ],
             "url": {
               "raw": "{{api_base_url}}/me",
-              "host": ["{{api_base_url}}"],
-              "path": ["me"]
+              "host": [
+                "{{api_base_url}}"
+              ],
+              "path": [
+                "me"
+              ]
             }
           },
           "response": []
@@ -155,7 +260,7 @@
                   "  const json = pm.response.json();",
                   "  pm.expect(json.statement_reference).to.be.a('string').and.not.empty;",
                   "  pm.expect(json.original_file_name).to.eql('sample-statement.pdf');",
-                  "  pm.expect(json.stored_file_name).to.match(/\\.pdf$/);",
+                  "  pm.expect(json.stored_file_name).to.match(/\\\\.pdf$/);",
                   "  pm.expect(json.content_type).to.eql('application/pdf');",
                   "  pm.expect(json.file_size_bytes).to.be.above(0);",
                   "  pm.expect(json.status).to.eql('UPLOADED');",
@@ -171,22 +276,51 @@
           "request": {
             "method": "POST",
             "header": [
-              {"key": "Authorization", "value": "Bearer {{access_token}}", "type": "text"}
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}",
+                "type": "text"
+              }
             ],
             "body": {
               "mode": "formdata",
               "formdata": [
-                {"type": "file", "contentType": "application/pdf", "key": "file", "src": "docs/postman/files/sample-statement.pdf"},
-                {"type": "text", "key": "institution", "value": "hdfc"},
-                {"type": "text", "key": "account_type", "value": "credit_card"},
-                {"type": "text", "key": "account_name", "value": "HDFC Test Card"},
-                {"type": "text", "key": "statement_format", "value": "hdfc_credit_card"}
+                {
+                  "type": "file",
+                  "contentType": "application/pdf",
+                  "key": "file",
+                  "src": "docs/postman/files/sample-statement.pdf"
+                },
+                {
+                  "type": "text",
+                  "key": "institution",
+                  "value": "hdfc"
+                },
+                {
+                  "type": "text",
+                  "key": "account_type",
+                  "value": "credit_card"
+                },
+                {
+                  "type": "text",
+                  "key": "account_name",
+                  "value": "HDFC Test Card"
+                },
+                {
+                  "type": "text",
+                  "key": "statement_format",
+                  "value": "hdfc_credit_card"
+                }
               ]
             },
             "url": {
               "raw": "{{api_base_url}}/ingest",
-              "host": ["{{api_base_url}}"],
-              "path": ["ingest"]
+              "host": [
+                "{{api_base_url}}"
+              ],
+              "path": [
+                "ingest"
+              ]
             },
             "description": "If Postman cannot resolve the relative file path, manually select docs/postman/files/sample-statement.pdf."
           },
@@ -215,8 +349,12 @@
             "header": [],
             "url": {
               "raw": "{{api_base_url}}/me",
-              "host": ["{{api_base_url}}"],
-              "path": ["me"]
+              "host": [
+                "{{api_base_url}}"
+              ],
+              "path": [
+                "me"
+              ]
             }
           },
           "response": []
@@ -244,13 +382,22 @@
             "body": {
               "mode": "formdata",
               "formdata": [
-                {"type": "file", "contentType": "application/pdf", "key": "file", "src": "docs/postman/files/sample-statement.pdf"}
+                {
+                  "type": "file",
+                  "contentType": "application/pdf",
+                  "key": "file",
+                  "src": "docs/postman/files/sample-statement.pdf"
+                }
               ]
             },
             "url": {
               "raw": "{{api_base_url}}/ingest",
-              "host": ["{{api_base_url}}"],
-              "path": ["ingest"]
+              "host": [
+                "{{api_base_url}}"
+              ],
+              "path": [
+                "ingest"
+              ]
             },
             "description": "If Postman cannot resolve the relative file path, manually select docs/postman/files/sample-statement.pdf."
           },
@@ -276,22 +423,51 @@
           "request": {
             "method": "POST",
             "header": [
-              {"key": "Authorization", "value": "Bearer {{access_token}}", "type": "text"}
+              {
+                "key": "Authorization",
+                "value": "Bearer {{access_token}}",
+                "type": "text"
+              }
             ],
             "body": {
               "mode": "formdata",
               "formdata": [
-                {"type": "file", "contentType": "application/pdf", "key": "file", "src": "docs/postman/files/invalid-sample-statement.pdf"},
-                {"type": "text", "key": "institution", "value": "hdfc"},
-                {"type": "text", "key": "account_type", "value": "credit_card"},
-                {"type": "text", "key": "account_name", "value": "HDFC Test Card"},
-                {"type": "text", "key": "statement_format", "value": "hdfc_credit_card"}
+                {
+                  "type": "file",
+                  "contentType": "application/pdf",
+                  "key": "file",
+                  "src": "docs/postman/files/invalid-sample-statement.pdf"
+                },
+                {
+                  "type": "text",
+                  "key": "institution",
+                  "value": "hdfc"
+                },
+                {
+                  "type": "text",
+                  "key": "account_type",
+                  "value": "credit_card"
+                },
+                {
+                  "type": "text",
+                  "key": "account_name",
+                  "value": "HDFC Test Card"
+                },
+                {
+                  "type": "text",
+                  "key": "statement_format",
+                  "value": "hdfc_credit_card"
+                }
               ]
             },
             "url": {
               "raw": "{{api_base_url}}/ingest",
-              "host": ["{{api_base_url}}"],
-              "path": ["ingest"]
+              "host": [
+                "{{api_base_url}}"
+              ],
+              "path": [
+                "ingest"
+              ]
             },
             "description": "Run Token first. If Postman cannot resolve the relative file path, manually select docs/postman/files/invalid-sample-statement.pdf."
           },

--- a/docs/postman/spend-analyser.postman_collection.json
+++ b/docs/postman/spend-analyser.postman_collection.json
@@ -260,7 +260,7 @@
                   "  const json = pm.response.json();",
                   "  pm.expect(json.statement_reference).to.be.a('string').and.not.empty;",
                   "  pm.expect(json.original_file_name).to.eql('sample-statement.pdf');",
-                  "  pm.expect(json.stored_file_name).to.match(/\\\\.pdf$/);",
+                  "  pm.expect(json.stored_file_name).to.match(/\\.pdf$/);",
                   "  pm.expect(json.content_type).to.eql('application/pdf');",
                   "  pm.expect(json.file_size_bytes).to.be.above(0);",
                   "  pm.expect(json.status).to.eql('UPLOADED');",

--- a/docs/postman/spend-analyser.postman_collection.json
+++ b/docs/postman/spend-analyser.postman_collection.json
@@ -1,0 +1,303 @@
+{
+  "info": {
+    "_postman_id": "538a7ee2-0f26-4995-b63a-77baa9bc24c5",
+    "name": "Spend Analyser",
+    "description": "Local smoke-test collection for Spend Analyzer.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Local Smoke Test",
+      "item": [
+        {
+          "name": "Health",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('Application health is OK', function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.status).to.eql('OK');",
+                  "  pm.expect(json.service.name).to.eql('Spend Analyzer');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{api_base_url}}/health",
+              "host": ["{{api_base_url}}"],
+              "path": ["health"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "DB Health",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('Database health is OK', function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.status).to.eql('OK');",
+                  "  pm.expect(json.checks.database.status).to.eql('OK');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{api_base_url}}/health/db",
+              "host": ["{{api_base_url}}"],
+              "path": ["health", "db"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Token",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "const json = pm.response.json();",
+                  "pm.test('Response contains access_token', function () { pm.expect(json.access_token).to.be.a('string').and.not.empty; });",
+                  "pm.test('Response contains bearer token type', function () { pm.expect(json.token_type.toLowerCase()).to.eql('bearer'); });",
+                  "pm.environment.set('access_token', json.access_token);"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {"key": "grant_type", "value": "password", "type": "text"},
+                {"key": "client_id", "value": "{{client_id}}", "type": "text"},
+                {"key": "username", "value": "{{username}}", "type": "text"},
+                {"key": "password", "value": "{{password}}", "type": "text"}
+              ]
+            },
+            "url": {
+              "raw": "{{idp_base_url}}/realms/{{realm}}/protocol/openid-connect/token",
+              "host": ["{{idp_base_url}}"],
+              "path": ["realms", "{{realm}}", "protocol", "openid-connect", "token"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Me",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('Authenticated user is test.user', function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.user_id).to.be.a('string').and.not.empty;",
+                  "  pm.expect(json.username).to.eql('test.user');",
+                  "  pm.expect(json.email).to.eql('test.user@example.com');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {"key": "Authorization", "value": "Bearer {{access_token}}", "type": "text"}
+            ],
+            "url": {
+              "raw": "{{api_base_url}}/me",
+              "host": ["{{api_base_url}}"],
+              "path": ["me"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Ingest",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
+                  "pm.test('Upload response has expected fields', function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.statement_reference).to.be.a('string').and.not.empty;",
+                  "  pm.expect(json.original_file_name).to.eql('sample-statement.pdf');",
+                  "  pm.expect(json.stored_file_name).to.match(/\\.pdf$/);",
+                  "  pm.expect(json.content_type).to.eql('application/pdf');",
+                  "  pm.expect(json.file_size_bytes).to.be.above(0);",
+                  "  pm.expect(json.status).to.eql('UPLOADED');",
+                  "  pm.expect(json.institution).to.eql('hdfc');",
+                  "  pm.expect(json.account_type).to.eql('credit_card');",
+                  "  pm.expect(json.account_name).to.eql('HDFC Test Card');",
+                  "  pm.expect(json.statement_format).to.eql('hdfc_credit_card');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {"key": "Authorization", "value": "Bearer {{access_token}}", "type": "text"}
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {"type": "file", "contentType": "application/pdf", "key": "file", "src": "docs/postman/files/sample-statement.pdf"},
+                {"type": "text", "key": "institution", "value": "hdfc"},
+                {"type": "text", "key": "account_type", "value": "credit_card"},
+                {"type": "text", "key": "account_name", "value": "HDFC Test Card"},
+                {"type": "text", "key": "statement_format", "value": "hdfc_credit_card"}
+              ]
+            },
+            "url": {
+              "raw": "{{api_base_url}}/ingest",
+              "host": ["{{api_base_url}}"],
+              "path": ["ingest"]
+            },
+            "description": "If Postman cannot resolve the relative file path, manually select docs/postman/files/sample-statement.pdf."
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Negative Tests",
+      "item": [
+        {
+          "name": "Me - Missing Token",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Missing token is rejected', function () { pm.response.to.have.status(401); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{api_base_url}}/me",
+              "host": ["{{api_base_url}}"],
+              "path": ["me"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Ingest - Missing Token",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Missing token is rejected', function () { pm.response.to.have.status(401); });",
+                  "pm.test('Error says not authenticated', function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.detail).to.eql('Not authenticated');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {"type": "file", "contentType": "application/pdf", "key": "file", "src": "docs/postman/files/sample-statement.pdf"}
+              ]
+            },
+            "url": {
+              "raw": "{{api_base_url}}/ingest",
+              "host": ["{{api_base_url}}"],
+              "path": ["ingest"]
+            },
+            "description": "If Postman cannot resolve the relative file path, manually select docs/postman/files/sample-statement.pdf."
+          },
+          "response": []
+        },
+        {
+          "name": "Ingest - Invalid PDF Content",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Invalid PDF content is rejected', function () { pm.response.to.have.status(400); });",
+                  "pm.test('Error identifies invalid PDF content', function () {",
+                  "  const json = pm.response.json();",
+                  "  pm.expect(json.detail).to.eql('Uploaded file content is not a valid PDF');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {"key": "Authorization", "value": "Bearer {{access_token}}", "type": "text"}
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {"type": "file", "contentType": "application/pdf", "key": "file", "src": "docs/postman/files/invalid-sample-statement.pdf"},
+                {"type": "text", "key": "institution", "value": "hdfc"},
+                {"type": "text", "key": "account_type", "value": "credit_card"},
+                {"type": "text", "key": "account_name", "value": "HDFC Test Card"},
+                {"type": "text", "key": "statement_format", "value": "hdfc_credit_card"}
+              ]
+            },
+            "url": {
+              "raw": "{{api_base_url}}/ingest",
+              "host": ["{{api_base_url}}"],
+              "path": ["ingest"]
+            },
+            "description": "Run Token first. If Postman cannot resolve the relative file path, manually select docs/postman/files/invalid-sample-statement.pdf."
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
+}

--- a/docs/postman/spend-analyser.postman_collection.json
+++ b/docs/postman/spend-analyser.postman_collection.json
@@ -7,326 +7,349 @@
   },
   "item": [
     {
-      "name": "Local",
-      "item": [
+      "name": "Health",
+      "event": [
         {
-          "name": "Health",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "pm.test('Application health is OK', function () {",
-                  "  const json = pm.response.json();",
-                  "  pm.expect(json.status).to.eql('OK');",
-                  "  pm.expect(json.service.name).to.eql('Spend Analyzer');",
-                  "});"
-                ]
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{api_base_url}}/health",
-              "host": [
-                "{{api_base_url}}"
-              ],
-              "path": [
-                "health"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "DB Health",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "pm.test('Database health is OK', function () {",
-                  "  const json = pm.response.json();",
-                  "  pm.expect(json.status).to.eql('OK');",
-                  "  pm.expect(json.checks.database.status).to.eql('OK');",
-                  "});"
-                ]
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{api_base_url}}/health/db",
-              "host": [
-                "{{api_base_url}}"
-              ],
-              "path": [
-                "health",
-                "db"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Docs",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "pm.test('Swagger UI HTML is returned', function () {",
-                  "  pm.expect(pm.response.text()).to.include('swagger-ui');",
-                  "});"
-                ]
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{api_base_url}}/docs",
-              "host": [
-                "{{api_base_url}}"
-              ],
-              "path": [
-                "docs"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "OpenAPI",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "pm.test('OpenAPI document is returned', function () {",
-                  "  const json = pm.response.json();",
-                  "  pm.expect(json.openapi).to.be.a('string').and.not.empty;",
-                  "  pm.expect(json.info.title).to.be.a('string').and.not.empty;",
-                  "});"
-                ]
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{api_base_url}}/openapi.json",
-              "host": [
-                "{{api_base_url}}"
-              ],
-              "path": [
-                "openapi.json"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Token",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "const json = pm.response.json();",
-                  "pm.test('Response contains access_token', function () { pm.expect(json.access_token).to.be.a('string').and.not.empty; });",
-                  "pm.test('Response contains bearer token type', function () { pm.expect(json.token_type.toLowerCase()).to.eql('bearer'); });",
-                  "pm.environment.set('access_token', json.access_token);"
-                ]
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Content-Type",
-                "value": "application/x-www-form-urlencoded",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "urlencoded",
-              "urlencoded": [
-                {
-                  "key": "grant_type",
-                  "value": "password",
-                  "type": "text"
-                },
-                {
-                  "key": "client_id",
-                  "value": "{{client_id}}",
-                  "type": "text"
-                },
-                {
-                  "key": "username",
-                  "value": "{{username}}",
-                  "type": "text"
-                },
-                {
-                  "key": "password",
-                  "value": "{{password}}",
-                  "type": "text"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{idp_base_url}}/realms/{{realm}}/protocol/openid-connect/token",
-              "host": [
-                "{{idp_base_url}}"
-              ],
-              "path": [
-                "realms",
-                "{{realm}}",
-                "protocol",
-                "openid-connect",
-                "token"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Me",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 200', function () { pm.response.to.have.status(200); });",
-                  "pm.test('Authenticated user is test.user', function () {",
-                  "  const json = pm.response.json();",
-                  "  pm.expect(json.user_id).to.be.a('string').and.not.empty;",
-                  "  pm.expect(json.username).to.eql('test.user');",
-                  "  pm.expect(json.email).to.eql('test.user@example.com');",
-                  "});"
-                ]
-              }
-            }
-          ],
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{access_token}}",
-                "type": "text"
-              }
-            ],
-            "url": {
-              "raw": "{{api_base_url}}/me",
-              "host": [
-                "{{api_base_url}}"
-              ],
-              "path": [
-                "me"
-              ]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Ingest",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "type": "text/javascript",
-                "exec": [
-                  "pm.test('Status code is 201', function () { pm.response.to.have.status(201); });",
-                  "pm.test('Upload response has expected fields', function () {",
-                  "  const json = pm.response.json();",
-                  "  pm.expect(json.statement_reference).to.be.a('string').and.not.empty;",
-                  "  pm.expect(json.original_file_name).to.eql('sample-statement.pdf');",
-                  "  pm.expect(json.stored_file_name).to.match(/\\.pdf$/);",
-                  "  pm.expect(json.content_type).to.eql('application/pdf');",
-                  "  pm.expect(json.file_size_bytes).to.be.above(0);",
-                  "  pm.expect(json.status).to.eql('UPLOADED');",
-                  "  pm.expect(json.institution).to.eql('hdfc');",
-                  "  pm.expect(json.account_type).to.eql('credit_card');",
-                  "  pm.expect(json.account_name).to.eql('HDFC Test Card');",
-                  "  pm.expect(json.statement_format).to.eql('hdfc_credit_card');",
-                  "});"
-                ]
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{access_token}}",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "formdata",
-              "formdata": [
-                {
-                  "type": "file",
-                  "contentType": "application/pdf",
-                  "key": "file",
-                  "src": "docs/postman/files/sample-statement.pdf"
-                },
-                {
-                  "type": "text",
-                  "key": "institution",
-                  "value": "hdfc"
-                },
-                {
-                  "type": "text",
-                  "key": "account_type",
-                  "value": "credit_card"
-                },
-                {
-                  "type": "text",
-                  "key": "account_name",
-                  "value": "HDFC Test Card"
-                },
-                {
-                  "type": "text",
-                  "key": "statement_format",
-                  "value": "hdfc_credit_card"
-                }
-              ]
-            },
-            "url": {
-              "raw": "{{api_base_url}}/ingest",
-              "host": [
-                "{{api_base_url}}"
-              ],
-              "path": [
-                "ingest"
-              ]
-            },
-            "description": "If Postman cannot resolve the relative file path, manually select docs/postman/files/sample-statement.pdf."
-          },
-          "response": []
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Status code is 200', function () {",
+              "  pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test('Application health is OK', function () {",
+              "  const json = pm.response.json();",
+              "  pm.expect(json.status).to.eql('OK');",
+              "  pm.expect(json.service.name).to.eql('Spend Analyzer');",
+              "});"
+            ]
+          }
         }
-      ]
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{api_base_url}}/health",
+          "host": [
+            "{{api_base_url}}"
+          ],
+          "path": [
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "DB Health",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Status code is 200', function () {",
+              "  pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test('Database health is OK', function () {",
+              "  const json = pm.response.json();",
+              "  pm.expect(json.status).to.eql('OK');",
+              "  pm.expect(json.checks.database.status).to.eql('OK');",
+              "});"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{api_base_url}}/health/db",
+          "host": [
+            "{{api_base_url}}"
+          ],
+          "path": [
+            "health",
+            "db"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Docs",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Status code is 200', function () {",
+              "  pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test('Swagger UI HTML is returned', function () {",
+              "  pm.expect(pm.response.text()).to.include('swagger-ui');",
+              "});"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{api_base_url}}/docs",
+          "host": [
+            "{{api_base_url}}"
+          ],
+          "path": [
+            "docs"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "OpenAPI",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Status code is 200', function () {",
+              "  pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test('OpenAPI document is returned', function () {",
+              "  const json = pm.response.json();",
+              "  pm.expect(json.openapi).to.be.a('string').and.not.empty;",
+              "  pm.expect(json.info.title).to.be.a('string').and.not.empty;",
+              "});"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{api_base_url}}/openapi.json",
+          "host": [
+            "{{api_base_url}}"
+          ],
+          "path": [
+            "openapi.json"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Token",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Status code is 200', function () {",
+              "  pm.response.to.have.status(200);",
+              "});",
+              "",
+              "const json = pm.response.json();",
+              "",
+              "pm.test('Response contains access_token', function () {",
+              "  pm.expect(json.access_token).to.be.a('string').and.not.empty;",
+              "});",
+              "",
+              "pm.test('Response contains bearer token type', function () {",
+              "  pm.expect(json.token_type.toLowerCase()).to.eql('bearer');",
+              "});",
+              "",
+              "pm.environment.set('access_token', json.access_token);"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/x-www-form-urlencoded",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "urlencoded",
+          "urlencoded": [
+            {
+              "key": "grant_type",
+              "value": "password",
+              "type": "text"
+            },
+            {
+              "key": "client_id",
+              "value": "{{client_id}}",
+              "type": "text"
+            },
+            {
+              "key": "username",
+              "value": "{{username}}",
+              "type": "text"
+            },
+            {
+              "key": "password",
+              "value": "{{password}}",
+              "type": "text"
+            }
+          ]
+        },
+        "url": {
+          "raw": "{{idp_base_url}}/realms/{{realm}}/protocol/openid-connect/token",
+          "host": [
+            "{{idp_base_url}}"
+          ],
+          "path": [
+            "realms",
+            "{{realm}}",
+            "protocol",
+            "openid-connect",
+            "token"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Me",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Status code is 200', function () {",
+              "  pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test('Authenticated user is test.user', function () {",
+              "  const json = pm.response.json();",
+              "  pm.expect(json.user_id).to.be.a('string').and.not.empty;",
+              "  pm.expect(json.username).to.eql('test.user');",
+              "  pm.expect(json.email).to.eql('test.user@example.com');",
+              "});"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{access_token}}",
+            "type": "text"
+          }
+        ],
+        "url": {
+          "raw": "{{api_base_url}}/me",
+          "host": [
+            "{{api_base_url}}"
+          ],
+          "path": [
+            "me"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Ingest",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Status code is 201', function () {",
+              "  pm.response.to.have.status(201);",
+              "});",
+              "",
+              "pm.test('Upload response has expected fields', function () {",
+              "  const json = pm.response.json();",
+              "  pm.expect(json.statement_reference).to.be.a('string').and.not.empty;",
+              "  pm.expect(json.original_file_name).to.eql('sample-statement.pdf');",
+              "  pm.expect(json.stored_file_name).to.match(/\\.pdf$/);",
+              "  pm.expect(json.content_type).to.eql('application/pdf');",
+              "  pm.expect(json.file_size_bytes).to.be.above(0);",
+              "  pm.expect(json.status).to.eql('UPLOADED');",
+              "  pm.expect(json.institution).to.eql('hdfc');",
+              "  pm.expect(json.account_type).to.eql('credit_card');",
+              "  pm.expect(json.account_name).to.eql('HDFC Test Card');",
+              "  pm.expect(json.statement_format).to.eql('hdfc_credit_card');",
+              "});"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{access_token}}",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            {
+              "type": "file",
+              "contentType": "application/pdf",
+              "key": "file",
+              "src": "docs/postman/files/sample-statement.pdf"
+            },
+            {
+              "type": "text",
+              "key": "institution",
+              "value": "hdfc"
+            },
+            {
+              "type": "text",
+              "key": "account_type",
+              "value": "credit_card"
+            },
+            {
+              "type": "text",
+              "key": "account_name",
+              "value": "HDFC Test Card"
+            },
+            {
+              "type": "text",
+              "key": "statement_format",
+              "value": "hdfc_credit_card"
+            }
+          ]
+        },
+        "url": {
+          "raw": "{{api_base_url}}/ingest",
+          "host": [
+            "{{api_base_url}}"
+          ],
+          "path": [
+            "ingest"
+          ]
+        },
+        "description": "If Postman cannot resolve the relative file path, manually select docs/postman/files/sample-statement.pdf."
+      },
+      "response": []
     },
     {
       "name": "Negative Tests",
@@ -339,7 +362,9 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('Missing token is rejected', function () { pm.response.to.have.status(401); });"
+                  "pm.test('Missing token is rejected', function () {",
+                  "  pm.response.to.have.status(401);",
+                  "});"
                 ]
               }
             }
@@ -367,7 +392,10 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('Missing token is rejected', function () { pm.response.to.have.status(401); });",
+                  "pm.test('Missing token is rejected', function () {",
+                  "  pm.response.to.have.status(401);",
+                  "});",
+                  "",
                   "pm.test('Error says not authenticated', function () {",
                   "  const json = pm.response.json();",
                   "  pm.expect(json.detail).to.eql('Not authenticated');",
@@ -411,7 +439,10 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('Invalid PDF content is rejected', function () { pm.response.to.have.status(400); });",
+                  "pm.test('Invalid PDF content is rejected', function () {",
+                  "  pm.response.to.have.status(400);",
+                  "});",
+                  "",
                   "pm.test('Error identifies invalid PDF content', function () {",
                   "  const json = pm.response.json();",
                   "  pm.expect(json.detail).to.eql('Uploaded file content is not a valid PDF');",


### PR DESCRIPTION
## Summary

Adds a sanitized Postman local smoke-test pack under `docs/postman` for validating the local Spend Analyzer API.

## Changes

- Adds a Postman collection for local API smoke testing.
- Adds requests for health, database health, docs, OpenAPI, token generation, authenticated user lookup, and statement ingestion.
- Adds response assertions for local smoke-test requests.
- Adds negative test requests for missing token and invalid upload behavior.
- Adds a sanitized local Postman environment template with no committed access token.
- Adds sample files for positive and negative ingestion testing.
- Adds `docs/postman/README.md` with import steps, run order, file-selection notes, and expected results.

## Notes

- The sample files contain dummy data only and are intended for upload and validation smoke testing, not parser accuracy validation.
- Postman may require manually selecting the fixture files if it does not resolve relative file paths after import.